### PR TITLE
Work with bosh

### DIFF
--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -146,10 +146,17 @@ func fillMachineIp(args *models.InstallerArguments, manifest models.Manifest, ma
 func fillSharedSecret(args *models.InstallerArguments, manifest models.Manifest) {
 	repJob := firstRepJob(manifest)
 	properties := repJob.Properties
-	if properties.MetronEndpoint == nil {
+	if properties.LoggregatorEndpoint == nil && properties.MetronEndpoint == nil {
 		properties = manifest.Properties
 	}
-	args.SharedSecret = properties.MetronEndpoint.SharedSecret
+	// grab the shared secret from the loggregator endpoint
+	if properties.LoggregatorEndpoint != nil {
+		args.SharedSecret = properties.LoggregatorEndpoint.SharedSecret
+	}
+	// in newer versions this is in the metron endpoint
+	if properties.MetronEndpoint != nil {
+		args.SharedSecret = properties.MetronEndpoint.SharedSecret
+	}
 }
 
 func fillMetronAgent(args *models.InstallerArguments, manifest models.Manifest, outputDir string) {
@@ -182,7 +189,7 @@ func fillSyslog(args *models.InstallerArguments, manifest models.Manifest) {
 		return
 	}
 
-	args.SyslogHostIP = properties.Syslog.Address
+	args.SyslogHostIP = properties.Syslog.Address[0]
 	args.SyslogPort = properties.Syslog.Port
 }
 

--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	installBatTemplate = `msiexec /passive /norestart /i %~dp0\DiegoWindows.msi ^{{ if .BbsRequireSsl }}
+	installBatTemplate = `msiexec /passive /norestart /log %~dp0\DiegoWindows.log /i %~dp0\DiegoWindows.msi ^{{ if .BbsRequireSsl }}
   BBS_CA_FILE=%~dp0\bbs_ca.crt ^
   BBS_CLIENT_CERT_FILE=%~dp0\bbs_client.crt ^
   BBS_CLIENT_KEY_FILE=%~dp0\bbs_client.key ^{{ end }}
@@ -54,7 +54,9 @@ const (
   METRON_AGENT_CERT_FILE=%~dp0\metron_agent.crt ^
   METRON_AGENT_KEY_FILE=%~dp0\metron_agent.key{{end}}
 
-msiexec /passive /norestart /i %~dp0\GardenWindows.msi ^
+msiexec /passive /norestart /log %~dp0\GardenWindows.log /i %~dp0\GardenWindows.msi ^
+  ADMIN_USERNAME={{.Username}} ^
+  ADMIN_PASSWORD={{.Password}} ^
   MACHINE_IP={{.MachineIp}}{{ if .SyslogHostIP }} ^
   SYSLOG_HOST_IP={{.SyslogHostIP}} ^
   SYSLOG_PORT={{.SyslogPort}}{{ end }}`

--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -115,6 +115,7 @@ func main() {
 	decoder := candiedyaml.NewDecoder(buf)
 	err = decoder.Decode(&manifest)
 	if err != nil {
+		err = fmt.Errorf("%s\n\n%s", buf, err.Error())
 		FailOnError(err)
 	}
 

--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -316,7 +316,8 @@ func extractMetronKeyAndCert(properties *models.Properties, outputDir string) {
 
 func FailOnError(err error) {
 	if err != nil {
-		panic(err)
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/src/models/models.go
+++ b/src/models/models.go
@@ -63,9 +63,13 @@ type LoggregatorProperties struct {
 		Machines []string `yaml:"machines"`
 	} `yaml:"etcd"`
 	Tls struct {
-		CA string `yaml:"ca"`
+		CA     string `yaml:"ca"`
 		CACert string `yaml:"ca_cert"`
 	} `yaml:"tls"`
+}
+
+type LoggregatorEndpoint struct {
+	SharedSecret string `yaml:"shared_secret"`
 }
 
 type MetronEndpoint struct {
@@ -74,28 +78,29 @@ type MetronEndpoint struct {
 
 type MetronAgent struct {
 	PreferredProtocol *string `yaml:"preferred_protocol"`
-	Tls struct {
+	Tls               struct {
 		ClientCert string `yaml:"client_cert"`
 		ClientKey  string `yaml:"client_key"`
 	} `yaml:"tls"`
-	TlsClient         struct {
+	TlsClient struct {
 		Cert string `yaml:"cert"`
 		Key  string `yaml:"key"`
 	} `yaml:"tls_client"`
 }
 
 type SyslogProperties struct {
-	Address string `yaml:"address"`
-	Port    string `yaml:"port"`
+	Address []string `yaml:"address"`
+	Port    string   `yaml:"port"`
 }
 
 type Properties struct {
-	Consul         *ConsulProperties      `yaml:"consul"`
-	Diego          *DiegoProperties       `yaml:"diego"`
-	Loggregator    *LoggregatorProperties `yaml:"loggregator"`
-	MetronEndpoint *MetronEndpoint        `yaml:"metron_endpoint"`
-	MetronAgent    *MetronAgent           `yaml:"metron_agent"`
-	Syslog         *SyslogProperties      `yaml:"syslog_daemon_config"`
+	Consul              *ConsulProperties      `yaml:"consul"`
+	Diego               *DiegoProperties       `yaml:"diego"`
+	Loggregator         *LoggregatorProperties `yaml:"loggregator"`
+	LoggregatorEndpoint *LoggregatorEndpoint   `yaml:"loggregator_endpoint"`
+	MetronEndpoint      *MetronEndpoint        `yaml:"metron_endpoint"`
+	MetronAgent         *MetronAgent           `yaml:"metron_agent"`
+	Syslog              *SyslogProperties      `yaml:"syslog_daemon_config"`
 }
 
 type Job struct {


### PR DESCRIPTION
This takes the newer version of the install script generator and makes it backwards compatible with older versions of BOSH.
- Also includes a workaround for the syslog IP being an array instead of a single valued string.
